### PR TITLE
Add GET messages API

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -1,0 +1,43 @@
+package courier
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type MessageResponse struct {
+	Id string
+	Status string
+	Enqueued int64
+	Delivered int64
+	Provider string
+	RecipientId string
+	EventId string
+	Configuration string
+	ProviderResponse string
+}
+
+func (c *Client) GetMessage(ctx context.Context, messageID string) (*MessageResponse, error) {
+
+	url := fmt.Sprintf(c.BaseUrl+"/messages/%s", messageID)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	bytes, err := c.doRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	var data MessageResponse
+	err = json.Unmarshal(bytes, &data)
+	if err != nil {
+		return nil, err
+	}
+
+	return &data, nil
+}

--- a/messages_test.go
+++ b/messages_test.go
@@ -1,0 +1,38 @@
+package courier_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/expel-io/courier-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClient_GetMessage(t *testing.T) {
+
+	requestMessageID := "1-23456789"
+	server := httptest.NewServer(http.HandlerFunc(
+
+		func(rw http.ResponseWriter, req *http.Request) {
+
+			assert.Equal(t, "/messages/"+requestMessageID, req.URL.String())
+
+			rw.Header().Add("Content-Type", "application/json")
+			rsp := `
+			{ "id" : "%s" }
+			`
+			_, _ = rw.Write([]byte(fmt.Sprintf(rsp, requestMessageID)))
+
+		}))
+	defer server.Close()
+
+	t.Run("makes requests for message ID", func(t *testing.T) {
+		client := courier.CourierClient("key", server.URL)
+		rsp ,err := client.GetMessage(context.Background(), requestMessageID)
+		assert.Nil(t, err)
+		assert.Equal(t, requestMessageID, rsp.Id)
+	})
+}


### PR DESCRIPTION
## Description of the change

Adds GET messages/:id api endpoint call

https://docs.trycourier.com/reference#getmessagebyid

> Description here

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
